### PR TITLE
[downlords-faf-client] Update to 2020.10.0

### DIFF
--- a/downlords-faf-client/PKGBUILD
+++ b/downlords-faf-client/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Martin Müllenhaupt <mm+aur.archlinux.org@netlair.de>
 pkgname=downlords-faf-client
-pkgver=1.4.7
+pkgver=2021.10.0
 _pkgver_major=$(echo $pkgver | cut -d . -f 1)
 _pkgver_minor=$(echo $pkgver | cut -d . -f 2)
 _pkgver_tag=$(echo $pkgver | cut -d . -f 3)
@@ -25,19 +25,21 @@ backup=()
 options=()
 install=
 changelog=
-source=("https://github.com/FAForever/downlords-faf-client/releases/download/v$_pkgver/$_filename" "https://github.com/FAForever/downlords-faf-client/raw/develop/src/media/appicon/128.png" 'DownlordsFafClient.desktop' 'downlords-faf-client')
-sha256sums=('ad49d8a1ad6a3ea39458cd45d75f047d8d3cf195f445383367264432d7c9961f'
+source=("https://github.com/FAForever/downlords-faf-client/releases/download/v$_pkgver/$_filename" "https://github.com/FAForever/downlords-faf-client/raw/develop/src/media/appicon/128.png" 'DownlordsFafClient.desktop' 'downlords-faf-client' 'faf-client.patch')
+sha256sums=('9c49aab5c21dbe9b7a49fe0eca3310407147a002f0e9e3ccbae5faec36e196c5'
             '2a5803ca2dd463aa4b53d79cff7f30e3aa7beb0d874b39c8ef59e679fbde9d3d'
             '3fd2b21da9de9f9c02dd89ee07f49c559dbb2de15f4e86a9b31f6353f608ffa6'
-            '2c1ded6e632263ef3e9a51f466285b3a51bacf7a8e61817e64d4ae4b4d7d1c42')
+            '014de2878ab4318b8fada673a918a8986418f15c2c72e6195a66eedb549422b5'
+            '3c7cb6a54bc0ca85155ed981f10095eb29c4684606d4e369c0e24ed8f5d06c86')
 noextract=()
 validpgpkeys=()
 
 package() {
   mkdir -p $pkgdir/usr/share/java
   tar xfv $_filename -C $pkgdir/usr/share/java
-  _subdir="downlords-faf-client-${_pkgver}"
+  _subdir="faf-client-${_pkgver}"
   mv $pkgdir/usr/share/java/$_subdir $pkgdir/usr/share/java/downlords-faf-client
+  patch -u $pkgdir/usr/share/java/downlords-faf-client/faf-client -i $srcdir/faf-client.patch
   install -D "$srcdir/DownlordsFafClient.desktop" "$pkgdir/usr/share/applications/DownlordsFafClient.desktop"
   install -D "$srcdir/downlords-faf-client" "$pkgdir/usr/bin/downlords-faf-client"
   install -D "$srcdir/128.png" "$pkgdir/usr/share/java/downlords-faf-client/icon.png"

--- a/downlords-faf-client/downlords-faf-client
+++ b/downlords-faf-client/downlords-faf-client
@@ -1,5 +1,5 @@
 #!/bin/sh
-export INSTALL4J_JAVA_HOME=/usr/lib/jvm/java-15-jdk
-pushd /usr/share/java/downlords-faf-client
-exec ./downlords-faf-client "$@"
-popd
+export INSTALL4J_JAVA_HOME=/usr/lib/jvm/default
+pushd /usr/share/java/downlords-faf-client > /dev/null
+exec ./faf-client "$@"
+popd > /dev/null

--- a/downlords-faf-client/faf-client.patch
+++ b/downlords-faf-client/faf-client.patch
@@ -1,0 +1,10 @@
+@@ -145,9 +145,6 @@
+   if [ "$ver_major" = "" ]; then
+     return;
+   fi
+-  if [ "$ver_major" -gt "15" ]; then
+-    return;
+-  fi
+ 
+   app_java_home=$test_dir
+ }


### PR DESCRIPTION
In addition to updating, I noted both the upstream client and your launcher script had the required JRE version fixed at 15, but the package dependency currently pulls higher versions (such as 17 for me). As such, I added a patch to the client's script to not error when JRE version is higher than 15, and modified the launcher script to use Arch's "default" java directory instead.

If a user needs to modify which JRE they wish to use, the client specifies you can set the environment variable `INSTALL4J_JAVA_HOME_OVERRIDE` to do so.