### PR TITLE
VSCode with launch option configs

### DIFF
--- a/visual-studio-code-bin/PKGBUILD
+++ b/visual-studio-code-bin/PKGBUILD
@@ -16,7 +16,7 @@ depends=(libxkbfile gnupg gtk3 libsecret nss gcc-libs libnotify libxss glibc lso
 optdepends=('glib2: Needed for move to trash functionality'
             'libdbusmenu-glib: Needed for KDE global menu'
             'org.freedesktop.secrets: Needed for settings sync')
-source=(${_pkgname}.desktop ${_pkgname}-url-handler.desktop ${_pkgname}-workspace.xml)
+source=(${_pkgname}.desktop ${_pkgname}-url-handler.desktop ${_pkgname}-workspace.xml ${_pkgname}-bin.sh)
 source_x86_64=(code_x64_${pkgver}.tar.gz::https://update.code.visualstudio.com/${pkgver}/linux-x64/stable)
 source_aarch64=(code_arm64_${pkgver}.tar.gz::https://update.code.visualstudio.com/${pkgver}/linux-arm64/stable)
 source_armv7h=(code_armhf_${pkgver}.tar.gz::https://update.code.visualstudio.com/${pkgver}/linux-armhf/stable)
@@ -24,9 +24,10 @@ source_armv7h=(code_armhf_${pkgver}.tar.gz::https://update.code.visualstudio.com
 # i686 uses "latest" instead of a specific version as it's not always updated in a timely manner
 source_i686=(code_ia32_${pkgver}.tar.gz::https://update.code.visualstudio.com/latest/linux-ia32/stable)
 # This generates cleaner checksums
-sha256sums=('07909803b0ce5e3412a92a2303e546c970ab48db505d6bf25fbd55dbb8466982'
-            'be3d123aacd575d8f836728266eb421ea70399d713d1fc30378dbc5602b519fb'
-            '24ba09a6398c9781ed7cb6f1a9f6f38ec204899ba1f33db92638bf6d3cb0aed6')
+sha256sums=('f0be273247878b66c7d10500718220e3e24abce29f7be94b4e875c3cf21b8a3b'
+            '730b9d57a6d5cd91611b01ad2f1f26b1b61c344a72e7d05fb7e27329c5234d4e'
+            '24ba09a6398c9781ed7cb6f1a9f6f38ec204899ba1f33db92638bf6d3cb0aed6'
+            'fb23f8716b87efadf0e4dc2ab60a96b03af90ef944b4475e103b68ebf8f66126')
 sha256sums_x86_64=('a45264bc2757d763ee3833ae2eb572cced0aba6d2e04346fda9097855470f4ad')
 sha256sums_i686=('64360439cc2fa596838062f7e6f9757b79d4b775a564f18bad6cbad154bf850c')
 sha256sums_aarch64=('4240df14ac90568a8cfeb8577982e32855a731baa5efd6897e6e135ce4d5efc9')
@@ -62,6 +63,10 @@ package() {
   install -Dm 644 "${srcdir}/${_pkg}/resources/completions/zsh/_code" "${pkgdir}/usr/share/zsh/site-functions/_code"
 
   cp -r "${srcdir}/${_pkg}/"* "${pkgdir}/opt/${_pkgname}" -R
-  ln -s /opt/${_pkgname}/bin/code "${pkgdir}"/usr/bin/code
+
+  # Launcher
+  echo "  -> Edit ~/.config/code-flags.conf to add launch flags..."
+	install -m755 "${srcdir}/${_pkgname}-bin.sh" "${pkgdir}/usr/bin/code"
+  # ln -s /opt/${_pkgname}/bin/code "${pkgdir}"/usr/bin/code
 }
 

--- a/visual-studio-code-bin/visual-studio-code-bin.sh
+++ b/visual-studio-code-bin/visual-studio-code-bin.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
+
+# Allow users to override command-line options
+if [[ -f $XDG_CONFIG_HOME/code-flags.conf ]]; then
+   CODE_USER_FLAGS="$(cat $XDG_CONFIG_HOME/code-flags.conf)"
+fi
+
+# Launch
+exec /opt/visual-studio-code/bin/code $CODE_USER_FLAGS "$@"

--- a/visual-studio-code-bin/visual-studio-code-url-handler.desktop
+++ b/visual-studio-code-bin/visual-studio-code-url-handler.desktop
@@ -2,7 +2,7 @@
 Name=Visual Studio Code - URL Handler
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
-Exec=/opt/visual-studio-code/code --no-sandbox --open-url %U
+Exec=/usr/bin/code --no-sandbox --open-url %U
 Icon=visual-studio-code
 Type=Application
 NoDisplay=true

--- a/visual-studio-code-bin/visual-studio-code.desktop
+++ b/visual-studio-code-bin/visual-studio-code.desktop
@@ -2,7 +2,7 @@
 Name=Visual Studio Code
 Comment=Code Editing. Refined.
 GenericName=Text Editor
-Exec=/opt/visual-studio-code/code --no-sandbox --unity-launch %F
+Exec=/usr/bin/code --no-sandbox --unity-launch %F
 Icon=visual-studio-code
 Type=Application
 StartupNotify=false
@@ -14,5 +14,5 @@ Keywords=vscode;
 
 [Desktop Action new-empty-window]
 Name=New Empty Window
-Exec=/opt/visual-studio-code/code --no-sandbox --new-window %F
+Exec=/usr/bin/code --no-sandbox --new-window %F
 Icon=visual-studio-code


### PR DESCRIPTION
- `visual-studio-code-bin.sh` > `/usr/bin/code` launch script that allows launch options configurable from `~/.config/code-flags.conf`
- Updated desktop entries exec to `/usr/bin/code`
- Updated PKGBUILD accordingly

Tested on 2 systems (Intel Iris Xe laptop, AMD Ryzen + NVIDIA desktop) with wayland options for electron, worked perfectly