### PR TITLE
Improve parsing of vscode launch options

### DIFF
--- a/visual-studio-code-bin/visual-studio-code-bin.sh
+++ b/visual-studio-code-bin/visual-studio-code-bin.sh
@@ -4,7 +4,7 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-~/.config}
 
 # Allow users to override command-line options
 if [[ -f $XDG_CONFIG_HOME/code-flags.conf ]]; then
-   CODE_USER_FLAGS="$(cat $XDG_CONFIG_HOME/code-flags.conf)"
+   CODE_USER_FLAGS="$(sed 's/#.*//' $XDG_CONFIG_HOME/code-flags.conf)"
 fi
 
 # Launch


### PR DESCRIPTION
This change allows user to comment out options, e.g. when experimenting.